### PR TITLE
UI-1856 Add support to override stroke-weight by css var

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.0
+=======
+* allow user to override stroke-width by css var
+
 v2.1.11
 =======
 * add px-vis:reset

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v2.1.11
+=======
+* add px-vis:reset
+* add px-vis:delta
+
 v2.1.10
 ==================
 * add px-nav:product-switcher

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Polymer component to allow easy use of Predix icons",
   "main": "px-icon-set.html",
   "ignore": [

--- a/icons/optimized-vis/_optimized-vis.html
+++ b/icons/optimized-vis/_optimized-vis.html
@@ -1,19 +1,3 @@
-<!--
-Copyright (c) 2018, General Electric
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 <g id="add-brush"><path stroke-linejoin="round" d="M16.5 14v7m3.5-3.5h-7M10.5 21V0"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M9 17.5H4.5v-14h12V12"/></g>
 <g id="all-points-in-area"><circle cx="10.5" cy="10.5" r="10" stroke-linejoin="round"/><path stroke-linejoin="round" d="M10.5 5v4M9 10.5H5m11 0h-4M10.5 12v4"/></g>
 <g id="bring-to-front"><path stroke-miterlimit="10" d="M15.5 15v.5"/><path stroke-miterlimit="10" stroke-dasharray="0.9 0.9" d="M15.5 16.4v3.15"/><path stroke-miterlimit="10" d="M15.5 20v.5H15"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M14 20.5H2.5"/><path stroke-miterlimit="10" d="M2 20.5h-.5V20"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M1.5 19V7.5"/><path stroke-miterlimit="10" d="M1.5 7v-.5H2"/><path stroke-miterlimit="10" stroke-dasharray="0.9 0.9" d="M2.9 6.5h3.15"/><path stroke-miterlimit="10" d="M6.5 6.5H7m-.5-5h14v14h-14z"/></g>
@@ -22,6 +6,7 @@ limitations under the License.
 <g id="closest-point-series"><path stroke-miterlimit="10" d="M0 21.5h22M.5 22V0"/><circle cx="6.34" cy="14.01" r="2.66"/><circle cx="6.34" cy="8.01" r="2.66"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M6.5 0v21"/><path d="M16.34 4.35a2.65 2.65 0 0 1 .62.08A2.65 2.65 0 0 0 17 4a2.66 2.66 0 1 0-3.28 2.58 2.66 2.66 0 0 1 2.62-2.23z" stroke-miterlimit="10"/><circle cx="12.34" cy="13.01" r="2.66" stroke-miterlimit="10"/><circle cx="18.34" cy="17.01" r="2.66" stroke-miterlimit="10"/><circle cx="16.34" cy="7.01" r="2.66" stroke-miterlimit="10"/></g>
 <g id="comment"><path d="M10 17.66l-3.37-4.28H.5V.5h19v12.88h-6.13L10 17.66zM3.87 4.18h12.26M3.87 6.63h8.58M3.87 9.08h4.9"/></g>
 <g id="crosshair"><path stroke-linejoin="round" d="M10.5 0v8M8 10.5H0m21 0h-8M10.5 13v8"/></g>
+<g id="delta"><path stroke-miterlimit="10" d="M13.44 20.67H1.5L11 1.63l9.5 19.04h-4.22L11 9.38"/></g>
 <g id="draw-stripe"><path stroke-linejoin="round" d="M16.5 14v7m3.5-3.5h-7M1.56 15.91L6.5 9.5l7 4 6.52-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M17 19.5H6.5v-18h10V12"/></g>
 <g id="expand-radius"><circle cx="11" cy="11" r="6.5" stroke-linejoin="round"/><path stroke-linejoin="round" d="M4 .5H.5V4M.5.5l4 4M18 .5h3.5V4m0-3.5l-4 4M4 21.5H.5V18m0 3.5l4-4m13.5 4h3.5V18m0 3.5l-4-4"/></g>
 <g id="full-screen"><rect x=".5" y=".5" width="21" height="21" rx="2" ry="2" stroke-linejoin="round"/><path stroke-linejoin="round" d="M4 18L18 4m-8-.5h8.5V12M12 18.5H3.5V10"/></g>
@@ -33,6 +18,7 @@ limitations under the License.
 <g id="refresh"><path stroke-linejoin="round" d="M15 6.5h5.5V1m1 10a10.49 10.49 0 1 1-1-4.49"/></g>
 <g id="remove-brush"><path stroke-linejoin="round" d="M10.5 21V0M20 17.5h-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M11 17.5H4.5v-14h12V14"/></g>
 <g id="remove-stripe"><path stroke-linejoin="round" d="M1.56 15.91L6.5 9.5l7 4 6.52-7m-.02 11h-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M17 19.5H6.5v-18h10V16"/></g>
+<g id="reset"><path d="M1.46 6.55c3.75-8.11 15.74-7.94 19.22.3C24.07 14.87 16.33 23.49 8 21A10.61 10.61 0 0 1 .51 11" stroke-miterlimit="10"/><path stroke-miterlimit="10" d="M6.88 6.44h-5.5V.94"/></g>
 <g id="reset-zoom"><path stroke-linejoin="round" d="M13 .5h8.5V9M9 21.5H.5V13m21 0v8.5H13M.5 9V.5H9"/></g>
 <g id="resize"><path d="M.5 0v22m.4-.5h15.3m.8-2.3l2.1 2.1 2.1-2.1m-7.57-3.35l-3.6 3.6-3.6-3.6m3.6-4.5v8m-3.6-14.6l3.6-3.6 3.6 3.6m-3.6 4.4v-8"/></g>
 <g id="show-tooltip"><circle cx="10.52" cy="10.5" r="10" stroke-linejoin="round"/><circle cx="10.52" cy="6.93" r=".5" stroke-linejoin="round"/><path stroke-linejoin="round" d="M10.52 9.79v5.71"/></g>

--- a/icons/optimized-vis/delta_22x22.svg
+++ b/icons/optimized-vis/delta_22x22.svg
@@ -1,0 +1,6 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <title>
+    delta
+  </title>
+  <path stroke-miterlimit="10" d="M13.44 20.67H1.5L11 1.63l9.5 19.04h-4.22L11 9.38"/>
+</svg>

--- a/icons/optimized-vis/reset_22x22.svg
+++ b/icons/optimized-vis/reset_22x22.svg
@@ -1,0 +1,7 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+  <title>
+    reset
+  </title>
+  <path d="M1.46 6.55c3.75-8.11 15.74-7.94 19.22.3C24.07 14.87 16.33 23.49 8 21A10.61 10.61 0 0 1 .51 11" stroke-miterlimit="10"/>
+  <path stroke-miterlimit="10" d="M6.88 6.44h-5.5V.94"/>
+</svg>

--- a/icons/src-vis/delta_22x22.svg
+++ b/icons/src-vis/delta_22x22.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22"><title>delta</title><polyline points="13.44 20.67 1.5 20.67 11 1.63 20.5 20.67 16.28 20.67 11 9.38" fill="none" stroke="#4c6472" stroke-miterlimit="10"/></svg>

--- a/icons/src-vis/reset_22x22.svg
+++ b/icons/src-vis/reset_22x22.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22"><title>reset</title><path d="M1.46,6.55c3.75-8.11,15.74-7.94,19.22.3C24.07,14.87,16.33,23.49,8,21a10.61,10.61,0,0,1-7.49-10" fill="none" stroke="#4c6472" stroke-miterlimit="10"/><polyline points="6.88 6.44 1.38 6.44 1.38 0.94" fill="none" stroke="#4c6472" stroke-miterlimit="10"/></svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "description": "Base icon styles for Predix UI",
   "private": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Base icon styles for Predix UI",
   "private": false,
   "scripts": {

--- a/px-icon-set-vis.html
+++ b/px-icon-set-vis.html
@@ -26,6 +26,7 @@ limitations under the License.
 <g id="closest-point-series"><path stroke-miterlimit="10" d="M0 21.5h22M.5 22V0"/><circle cx="6.34" cy="14.01" r="2.66"/><circle cx="6.34" cy="8.01" r="2.66"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M6.5 0v21"/><path d="M16.34 4.35a2.65 2.65 0 0 1 .62.08A2.65 2.65 0 0 0 17 4a2.66 2.66 0 1 0-3.28 2.58 2.66 2.66 0 0 1 2.62-2.23z" stroke-miterlimit="10"/><circle cx="12.34" cy="13.01" r="2.66" stroke-miterlimit="10"/><circle cx="18.34" cy="17.01" r="2.66" stroke-miterlimit="10"/><circle cx="16.34" cy="7.01" r="2.66" stroke-miterlimit="10"/></g>
 <g id="comment"><path d="M10 17.66l-3.37-4.28H.5V.5h19v12.88h-6.13L10 17.66zM3.87 4.18h12.26M3.87 6.63h8.58M3.87 9.08h4.9"/></g>
 <g id="crosshair"><path stroke-linejoin="round" d="M10.5 0v8M8 10.5H0m21 0h-8M10.5 13v8"/></g>
+<g id="delta"><path stroke-miterlimit="10" d="M13.44 20.67H1.5L11 1.63l9.5 19.04h-4.22L11 9.38"/></g>
 <g id="draw-stripe"><path stroke-linejoin="round" d="M16.5 14v7m3.5-3.5h-7M1.56 15.91L6.5 9.5l7 4 6.52-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M17 19.5H6.5v-18h10V12"/></g>
 <g id="expand-radius"><circle cx="11" cy="11" r="6.5" stroke-linejoin="round"/><path stroke-linejoin="round" d="M4 .5H.5V4M.5.5l4 4M18 .5h3.5V4m0-3.5l-4 4M4 21.5H.5V18m0 3.5l4-4m13.5 4h3.5V18m0 3.5l-4-4"/></g>
 <g id="full-screen"><rect x=".5" y=".5" width="21" height="21" rx="2" ry="2" stroke-linejoin="round"/><path stroke-linejoin="round" d="M4 18L18 4m-8-.5h8.5V12M12 18.5H3.5V10"/></g>
@@ -37,6 +38,7 @@ limitations under the License.
 <g id="refresh"><path stroke-linejoin="round" d="M15 6.5h5.5V1m1 10a10.49 10.49 0 1 1-1-4.49"/></g>
 <g id="remove-brush"><path stroke-linejoin="round" d="M10.5 21V0M20 17.5h-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M11 17.5H4.5v-14h12V14"/></g>
 <g id="remove-stripe"><path stroke-linejoin="round" d="M1.56 15.91L6.5 9.5l7 4 6.52-7m-.02 11h-7"/><path stroke-miterlimit="10" stroke-dasharray="1 1" d="M17 19.5H6.5v-18h10V16"/></g>
+<g id="reset"><path d="M1.46 6.55c3.75-8.11 15.74-7.94 19.22.3C24.07 14.87 16.33 23.49 8 21A10.61 10.61 0 0 1 .51 11" stroke-miterlimit="10"/><path stroke-miterlimit="10" d="M6.88 6.44h-5.5V.94"/></g>
 <g id="reset-zoom"><path stroke-linejoin="round" d="M13 .5h8.5V9M9 21.5H.5V13m21 0v8.5H13M.5 9V.5H9"/></g>
 <g id="resize"><path d="M.5 0v22m.4-.5h15.3m.8-2.3l2.1 2.1 2.1-2.1m-7.57-3.35l-3.6 3.6-3.6-3.6m3.6-4.5v8m-3.6-14.6l3.6-3.6 3.6 3.6m-3.6 4.4v-8"/></g>
 <g id="show-tooltip"><circle cx="10.52" cy="10.5" r="10" stroke-linejoin="round"/><circle cx="10.52" cy="6.93" r=".5" stroke-linejoin="round"/><path stroke-linejoin="round" d="M10.52 9.79v5.71"/></g>

--- a/px-icon.html
+++ b/px-icon.html
@@ -25,6 +25,7 @@ limitations under the License.
         /* Create some vars we can manipulate asour icons change*/
         --px-icon-default-width: 22px;
         --px-icon-default-height: 22px;
+        --px-icon-stroke-width: 1;
 
         /* Update iron-icon vars so we can overwrite */
         --iron-icon-width: var(--px-icon-default-width);
@@ -45,6 +46,7 @@ limitations under the License.
 
         width: var(--iron-icon-width);
         height: var(--iron-icon-height);
+        stroke-width: var(--px-icon-stroke-width);
         @apply --iron-icon;
       }
       /* Also copied exactly from iron-icon */


### PR DESCRIPTION
# Pull Request
Added support within css only to override a singular icon's stroke-width via css, using a new var: `--px-icon-stroke-width`, needed for ServiceMax Engineering
