### PR TITLE
UI-3217: Icon pin in map is too large in Firefox.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.6
+=======
+* Fix: Icon pin in map is too large in Firefox.
+
 v2.2.5
 =======
 * px-smx:crew and px-smx:resource icons using full canvas size

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Polymer component to allow easy use of Predix icons",
   "main": "px-icon-set.html",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Base icon styles for Predix UI",
   "private": false,
   "scripts": {

--- a/px-icon.html
+++ b/px-icon.html
@@ -71,6 +71,8 @@ limitations under the License.
         color: inherit;
         fill: inherit;
         stroke: inherit;
+        width: inherit;
+        height: inherit;
       }
     </style>
     <iron-icon icon="[[icon]]"></iron-icon>


### PR DESCRIPTION
- Icon pin in map is too large in Firefox.