### PR TITLE
Arrow direction mirror wrongly on RTL fox

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v2.2.7
+=======
+* Add css for rotating 'Next' and 'Prev' icon as they are mirrored for RTL users which is incorrect.
+
 v2.2.6
 =======
 * Fix: Icon pin in map is too large in Firefox.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Polymer component to allow easy use of Predix icons",
   "main": "px-icon-set.html",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-icon-set",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Base icon styles for Predix UI",
   "private": false,
   "scripts": {

--- a/px-icon.html
+++ b/px-icon.html
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../polymer/polymer.html"/>
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html"/>
-<link rel="import" href="../iron-icon/iron-icon.html"/>
+<link rel="import" href="../polymer/polymer.html" />
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html" />
+<link rel="import" href="../iron-icon/iron-icon.html" />
 
 <dom-module id="px-icon">
   <template>
@@ -49,16 +49,19 @@ limitations under the License.
         stroke-width: var(--px-icon-stroke-width);
         @apply --iron-icon;
       }
+
       /* Also copied exactly from iron-icon */
       :host([hidden]) {
         display: none;
       }
+
       /* Set default sizes for all icons sets */
       :host([icon^='px-utl']),
       :host([icon^='px-doc']) {
         --px-icon-default-width: 16px;
         --px-icon-default-height: 16px;
       }
+
       :host([icon^='px-smx']),
       :host([icon^='px-obj']),
       :host([icon^='px-fea']),
@@ -66,6 +69,19 @@ limitations under the License.
         --px-icon-default-width: 32px;
         --px-icon-default-height: 32px;
       }
+
+      /* For "RTL" users, the next and prev icon are mirrored which should not be the case ,
+        So when the direction of render is "RTL" then rotate the icon , just next and Prev
+      */
+
+      :host([icon^='px-nav:back']):host-context([dir='rtl']) {
+        transform: rotate(180deg);
+      }
+
+      :host([icon^='px-nav:next']):host-context([dir='rtl']) {
+        transform: rotate(180deg);
+      }
+
       /* Forces iron-icon to inherit the :host scoped fill/stroke styles */
       iron-icon {
         color: inherit;
@@ -74,13 +90,14 @@ limitations under the License.
         width: inherit;
         height: inherit;
       }
+
     </style>
     <iron-icon icon="[[icon]]"></iron-icon>
   </template>
 </dom-module>
 <script>
   Polymer({
-    is:'px-icon',
+    is: 'px-icon',
     properties: {
       icon: {
         type: String,
@@ -89,7 +106,7 @@ limitations under the License.
       }
     },
 
-    _updateStylesIndirect: function() {
+    _updateStylesIndirect: function () {
       //calling this without argument
       this.updateStyles();
     }


### PR DESCRIPTION
**Issue:** 

When rendered on "RTL" mode, the arrow icon (Prev and Next) is mirrored  incorrectly.

**Solution:** 

The fix is to find if the html has the direction of rtl and then rotate the "Next" and "Prev" icon. 

**Catch:**

So all these polymer components have the shadow-root and we can style the shadow root without using [host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host()) and [host-context](https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context()) to access that shadow root 

The downside to this , altho all polymer components use host, host-context is not supported in all browsers. Please refer the above link for `host` and `host-context` for detailed browser support. 

